### PR TITLE
main.py: display salon names instead of full Google Maps URLs

### DIFF
--- a/find_salon/main.py
+++ b/find_salon/main.py
@@ -4,6 +4,7 @@ from .scraper.driver import get_driver
 from .scraper.excel import save_to_excel
 from .scraper.extractor import extract_salon_data
 from .scraper.search import search_salons
+from .scraper.utils import extract_salon_name_from_url
 
 
 def main():
@@ -33,7 +34,8 @@ def main():
 
         all_data = []
         for idx, url in enumerate(urls, start=1):
-            print(f"[{idx}/{len(urls)}] Scraping: {url}")
+            salon_name = extract_salon_name_from_url(url)
+            print(f"[{idx}/{len(urls)}] Scraping: {salon_name}")
             data = extract_salon_data(driver, url)
             all_data.append(data)
 

--- a/find_salon/scraper/utils.py
+++ b/find_salon/scraper/utils.py
@@ -1,0 +1,16 @@
+from urllib.parse import urlparse
+
+
+def extract_salon_name_from_url(url):
+    """
+    Extracts the salon name from a Google Maps URL by parsing the /place/<name>/... pattern.
+    Returns a human-readable name.
+    """
+    try:
+        path_parts = urlparse(url).path.split("/")
+        if "place" in path_parts:
+            raw_name = path_parts[path_parts.index("place") + 1]
+            return raw_name.replace("+", " ")
+    except Exception:
+        pass
+    return "Unknown Salon"


### PR DESCRIPTION
	Modified CLI output to show only the salon names extracted from Google Maps URLs,
	making the output cleaner and easier to read during scraping.
	This improves readability and focuses on relevant information.